### PR TITLE
Create Induction and Fermat's Last Theorem: Hypothetical Attempts.md

### DIFF
--- a/Induction and Fermat's Last Theorem: Hypothetical Attempts.md
+++ b/Induction and Fermat's Last Theorem: Hypothetical Attempts.md
@@ -1,0 +1,54 @@
+Fermat's Last Theorem states that there are no three positive integers \( a \), \( b \), and \( c \) that satisfy the equation
+
+\[
+a^n + b^n = c^n
+\]
+
+for any integer \( n > 2 \). 
+
+While Fermat's Last Theorem was famously proven by Andrew Wiles in 1994 using sophisticated tools from modern algebraic geometry and modular forms, **induction alone cannot prove Fermat's Last Theorem**. This is because induction, as a proof technique, typically requires a straightforward, structured dependency between cases, which is not present in the complexity of Fermat's Last Theorem.
+
+---
+
+### **Why Induction Fails for Fermat's Last Theorem**
+1. **Nature of the Statement**: Fermat's Last Theorem deals with an infinite set of \( n \)-values, and the difficulty lies in showing that no solutions exist for all \( n > 2 \). Induction works well for statements that build incrementally (e.g., properties of integers or recursive structures), but Fermat's Last Theorem doesn't have this type of dependency between values of \( n \).
+
+2. **Complexity of the Proof**: Wiles' proof relies on highly non-trivial mathematics (e.g., elliptic curves, Galois representations) that can't be captured with basic induction.
+
+---
+
+### **Induction and Fermat's Last Theorem: Hypothetical Attempts**
+To explore why induction fails, let’s examine a naive attempt to apply induction:
+
+#### **Base Case**:
+For \( n = 3 \), we need to show that there are no integers \( a, b, c > 0 \) such that:
+\[
+a^3 + b^3 = c^3
+\]
+This can be proven separately (though not trivially) using number-theoretic techniques.
+
+#### **Inductive Step**:
+Assume the theorem is true for some \( n = k \):  
+\[
+a^k + b^k \neq c^k
+\]
+for all positive integers \( a, b, c \).
+
+Now, try to prove it for \( n = k+1 \):  
+\[
+a^{k+1} + b^{k+1} \neq c^{k+1}
+\]
+
+---
+
+### **The Problem with Induction**
+- The equation \( a^{k+1} + b^{k+1} = c^{k+1} \) does not have a direct or obvious structural relationship with \( a^k + b^k = c^k \). The higher powers of integers do not incrementally build on the lower powers in a way that allows induction to proceed.
+- Fermat's Last Theorem is fundamentally different for every exponent \( n > 2 \), so the hypothesis for \( n = k \) does not inherently imply the result for \( n = k+1 \).
+
+---
+
+### **Key Takeaway**
+- Fermat's Last Theorem cannot be proven by induction because it requires tools from advanced algebraic geometry, such as modular forms and elliptic curves, to link the equation to modularity of elliptic curves.
+- The proof by Andrew Wiles shows that every semistable elliptic curve is modular, which indirectly confirms Fermat’s Last Theorem via a connection to the Taniyama-Shimura-Weil conjecture.
+
+Induction is a beautiful tool, but it is not suited for proving a theorem of this depth and complexity.


### PR DESCRIPTION
Fermat's Last Theorem states that there are no three positive integers \( a \), \( b \), and \( c \) that satisfy the equation

\[
a^n + b^n = c^n
\]

for any integer \( n > 2 \). 

While Fermat's Last Theorem was famously proven by Andrew Wiles in 1994 using sophisticated tools from modern algebraic geometry and modular forms, **induction alone cannot prove Fermat's Last Theorem**. This is because induction, as a proof technique, typically requires a straightforward, structured dependency between cases, which is not present in the complexity of Fermat's Last Theorem.

---

### **Why Induction Fails for Fermat's Last Theorem**
1. **Nature of the Statement**: Fermat's Last Theorem deals with an infinite set of \( n \)-values, and the difficulty lies in showing that no solutions exist for all \( n > 2 \). Induction works well for statements that build incrementally (e.g., properties of integers or recursive structures), but Fermat's Last Theorem doesn't have this type of dependency between values of \( n \).

2. **Complexity of the Proof**: Wiles' proof relies on highly non-trivial mathematics (e.g., elliptic curves, Galois representations) that can't be captured with basic induction.

---

### **Induction and Fermat's Last Theorem: Hypothetical Attempts** To explore why induction fails, let’s examine a naive attempt to apply induction:

#### **Base Case**:
For \( n = 3 \), we need to show that there are no integers \( a, b, c > 0 \) such that: \[
a^3 + b^3 = c^3
\]
This can be proven separately (though not trivially) using number-theoretic techniques.

#### **Inductive Step**:
Assume the theorem is true for some \( n = k \):   \[
a^k + b^k \neq c^k
\]
for all positive integers \( a, b, c \).

Now, try to prove it for \( n = k+1 \):  
\[
a^{k+1} + b^{k+1} \neq c^{k+1}
\]

---

### **The Problem with Induction**
- The equation \( a^{k+1} + b^{k+1} = c^{k+1} \) does not have a direct or obvious structural relationship with \( a^k + b^k = c^k \). The higher powers of integers do not incrementally build on the lower powers in a way that allows induction to proceed.
- Fermat's Last Theorem is fundamentally different for every exponent \( n > 2 \), so the hypothesis for \( n = k \) does not inherently imply the result for \( n = k+1 \).

---

### **Key Takeaway**
- Fermat's Last Theorem cannot be proven by induction because it requires tools from advanced algebraic geometry, such as modular forms and elliptic curves, to link the equation to modularity of elliptic curves.
- The proof by Andrew Wiles shows that every semistable elliptic curve is modular, which indirectly confirms Fermat’s Last Theorem via a connection to the Taniyama-Shimura-Weil conjecture.

Induction is a beautiful tool, but it is not suited for proving a theorem of this depth and complexity.